### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/martinosoyen/ce6f0095-fbcc-4f95-9810-2892bfcfb44f/89e39283-368e-49c9-bd79-d5e33a0fef51/_apis/work/boardbadge/82fac952-67cc-4b53-ab2c-b640fed20bbf)](https://dev.azure.com/martinosoyen/ce6f0095-fbcc-4f95-9810-2892bfcfb44f/_boards/board/t/89e39283-368e-49c9-bd79-d5e33a0fef51/Microsoft.RequirementCategory)
 # Google AAP Practice Project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/martinosoyen/ce6f0095-fbcc-4f95-9810-2892bfcfb44f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.